### PR TITLE
Refer to wiki page for Nominatim alternatives

### DIFF
--- a/policies/nominatim.md
+++ b/policies/nominatim.md
@@ -52,10 +52,6 @@ Please be aware that this usage policy may change without notice. In particular,
 
 ## Alternatives / Third-party providers
 
-For slightly larger requirements you may be able to use one the various third-party providers, though of course you will need to agree to their terms of service.
-
-* [MapQuest Open](http://developer.mapquest.com/web/products/open/nominatim)
-* [OpenCage Geocoder](http://geocoder.opencagedata.com/)
-* [MapZen Search (pelias geocoder)](https://mapzen.com/projects/search/)
+For slightly larger requirements you may be able to use commercial third-party providers. Some are listed on the [Nominatim wiki page](https://wiki.openstreetmap.org/wiki/Nominatim#Alternatives_.2F_Third-party_providers).
 
 If your requirements are even larger you can [install your own instance](https://wiki.openstreetmap.org/wiki/Nominatim/Installation) of Nominatim.


### PR DESCRIPTION
The list of alternative geocoding providers is nothing that is officially approved or endorsed. In the wiki providers basically added and removed themselves. That worked okay and I would suggest to keep it that way.

I've added now an Alternatives section on the main Nominatim wiki page and this changes the policy to refer to that section.