### PR TITLE
Fix spelling mistake

### DIFF
--- a/_posts/2017-06-01-june.md
+++ b/_posts/2017-06-01-june.md
@@ -11,5 +11,5 @@ The nominatim geocoder database was reloaded.
 # Tile server reload and upgrade
 
 All four tile rendering servers were upgraded to openstreetmap-carto 4.0.0 which required a
-reload of the rendering database on each machine using the hstore based style. THe rendering
+reload of the rendering database on each machine using the hstore based style. The rendering
 databases were upgraded to Postgres 9.6 at the same time.


### PR DESCRIPTION
Just a tiny spelling mistake in the 2017 June post.