### PR TITLE
Add extra line gap for Feb 16 post

### DIFF
--- a/_posts/2016-02-01-february.md
+++ b/_posts/2016-02-01-february.md
@@ -7,6 +7,7 @@ date: 2016-02-29 23:59:59
 # IC power disruption
 
 In order to carry out maintenance, one of the power distribution units at IC was shut down. All of OSM's machines at IC have reduncant PSUs on separate supplies, but just in case of secondary failures [spike-01](https://hardware.openstreetmap.org/servers/spike-01.openstreetmap.org/) and [thorn-01](https://hardware.openstreetmap.org/servers/thorn-01.openstreetmap.org/) were moved onto separate supplies.
+
 # SSL certificate renewed
 
 Although [letsencrypt]() looks like being a much better way to do SSL certificates in the future, there are still many issues with Java. In these early stages, letsencrypt also imposes rate limits which make using their certificates quite onerous. Until these issues are sorted out, it seems like it would cause too much disruption to move now - it will be re-assessed next year. [Ticket](https://github.com/openstreetmap/operations/issues/55).


### PR DESCRIPTION
As seen [here](https://operations.osmfoundation.org/2016/02/29/february.html), not adding the gap causes the header to not display.
![screenshot](http://i.imgur.com/0o9lNoK.png)