### PR TITLE
Top donors also on about, plus note closeable box

### DIFF
--- a/policies/hosting-credit.md
+++ b/policies/hosting-credit.md
@@ -7,6 +7,7 @@ permalink: /policies/hosting/
 
 OWG has adopted the following policy for giving credit to supporters who donate hardware or hosting to OSMF. OWG will:
 
-1. Credit everyone on [https://hardware.openstreetmap.org/thanks](https://hardware.openstreetmap.org/thanks) and link to that page from [http://osm.org/about](http://osm.org/about)
-2. Credit the top 3 donors by equivalent £/yr value on the [front page](http://www.openstreetmap.org/) (currently, UCL, Bytemark and IC), as "Hosting supported by \<donor direct links>, and others \<link to hardware.osm.org/thanks>."
-3. Try to publicise new supporters who are donating hardware of hosting from time to time via blog posts, tweets and other publicity channels.
+1. Credit everyone on [https://hardware.openstreetmap.org/thanks](https://hardware.openstreetmap.org/thanks).
+2. On the [http://osm.org/about](http://osm.org/about) page, and in a closeable box on the [front page](http://www.openstreetmap.org/), link to the "Thanks" page
+3. On the [http://osm.org/about](http://osm.org/about) page, and in a closeable box on the [front page](http://www.openstreetmap.org/), credit the top 3 donors by equivalent £/yr value (currently, UCL, Bytemark and IC), as "Hosting supported by \<donor direct links>, and others \<link to hardware.osm.org/thanks>."
+4. Try to publicise new supporters who are donating hardware or hosting from time to time via blog posts, tweets and other publicity channels.


### PR DESCRIPTION
* We both link to the thanks page, and we credit the top donors on both the 'About' page and the front page box.
* Note that it's a "closeable box" on the front page.
* fix typo 'of'->'or'