### PR TITLE
Split out Acceptable Use Policies heading

### DIFF
--- a/policies/index.md
+++ b/policies/index.md
@@ -6,9 +6,14 @@ title: OWG Policies
 
 OWG has various policies:
 
-* [Hosting Provider Credit Policy]({{ site.baseurl }}/policies/hosting/)
+## Acceptable Use Policies
+Acceptable Use Policies for OpenStreetMap Foundation servers/services:
+
 * [Tile Usage Policy]({{ site.baseurl }}/policies/tiles/)
 * [Nominatim Usage Policy]({{ site.baseurl }}/policies/nominatim/)
 * [API Usage Policy]({{ site.baseurl }}/policies/api/)
+
+## Other OWG polices
+* [Hosting Provider Credit Policy]({{ site.baseurl }}/policies/hosting/)
 * [Operations Working Group Membership Policy]({{ site.baseurl }}/policies/owg-membership/)
 * [Sysadmin Membership Policy]({{ site.baseurl }}/policies/sysadmin-membership)


### PR DESCRIPTION
Split the list into a separate "Acceptable Use Policies" and "Other".

It's probably a bit clearer anyway, but the main reason for this is to then swap the "Acceptable Use Policies" link on the main about page https://www.openstreetmap.org/about to point here.