### PR TITLE
Add a Service Classification Policy

### DIFF
--- a/policies/classification.md
+++ b/policies/classification.md
@@ -1,0 +1,45 @@
+---
+title: Service Classification Policy
+permalink: /policies/classification/
+---
+
+The Operations Working Group internally classifies services it runs as primary, secondary, and tertiary. This allows us to prioritise when budgeting and planning systems.This policy sets out grounds for classification and a current list of each service.
+
+## Primary services
+Our primary services are the editing API and raw OSM data downloads. Any internal services required to enable these are therefore also considered primary services.
+
+### Current primary services
+* Editing API
+* Editing portion of the website (but not e.g. diaries or GPX)
+* Planet.osm.org, planet file generation and replication diffs
+* DNS for openstreetmap.org and osm.org
+
+## Secondary services
+Secondary services are services which are used for editing but not a requirement, and only the OSMF could run them; or essential to the experience on osm.org, but others could run them.
+
+### Current secondary services
+* "Standard" rendering (tile.openstreetmap.org)
+* Nominatim (nominatim.openstreetmap.org)
+* OpenStreetMap Wiki (wiki.openstretmap.org)
+* Portions of the website that are not primary services (e.g. diaries or GPX)
+
+## Tertiary services
+### Current tertiary services
+* Help (help.openstretmap.org)
+* Official Blog (blog.openstretmap.org)
+* OSMF website (www.osmfoundation.org)
+* Munin (munin.openstreetmap.org)
+* Mailing Lists (lists.openstreetmap.org)
+* SVN (svn.openstreetmap.org)
+* Trac (trac.openstreetmap.org)
+* git (git.openstreetmap.org)
+* IRC gateway (irc.openstreetmap.org)
+* Dev server (toolserver) (dev.openstreetmap.org)
+* Switch2OSM (switch2osm.org)
+* OSMF hosted imagery
+* Taginfo (taginfo.openstreetmap.org)
+* Forum (forum.openstreetmap.org)
+
+* Internal OSMF wikis
+* OTRS
+* Piwik

--- a/policies/index.md
+++ b/policies/index.md
@@ -19,3 +19,4 @@ Our internal policies govern the way that OWG operates:
 * [Operations Working Group Membership Policy]({{ site.baseurl }}/policies/owg-membership/)
 * [Sysadmin Membership Policy]({{ site.baseurl }}/policies/sysadmin-membership)
 * [Hosting Provider Credit Policy]({{ site.baseurl }}/policies/hosting/)
+* [Service Classification Policy]({{ site.baseurl }}/policies/classification/)


### PR DESCRIPTION
This is a formalization of the policy we've had, as documented in talks on OSMF infrastructure.

It still needs approval via OWG circular, and we should decide if we want to change the classifications of any services.