### PR TITLE
Remove export call from tiles usage policy

### DIFF
--- a/policies/tiles.md
+++ b/policies/tiles.md
@@ -22,7 +22,6 @@ Use of any OSMF provided service is further governed by the [OSMF Terms of Use](
 * Heavy use (e.g. distributing an app that uses tiles from openstreetmap.org) is **forbidden** without prior permission from the [Operations Working Group](https://wiki.osmfoundation.org/wiki/Operations_Working_Group). See below for alternatives.
 * Clearly display [license](https://wiki.openstreetmap.org/wiki/License) [attribution](https://wiki.osmfoundation.org/wiki/Licence/Attribution_Guidelines).
 * Do not actively or passively encourage copyright infringement.
-* Calls to **/cgi-bin/export** may only be triggered by direct end-user action. (For example: "click here to export".) The export call is an expensive (CPU+RAM) function to run and will frequently reject when server is under high load.
 * Recommended: Do not hardcode any URL at tile.openstreetmap.org as doing so will limit your ability to react quickly if the service is disrupted or blocked.
 * Recommended: add a link to [https://www.openstreetmap.org/fixthemap](https://www.openstreetmap.org/fixthemap) to allow your users to report and fix problems in our data.
 


### PR DESCRIPTION
The export call is restricted to openstreetmap.org usage only via a totp token. As it is no longer available for general usage (and in practice, hasn't before that due to load reasons), it does not belong on the tile usage policy.

Additionally, it is served from a different domain name, so the fact that it shares some resources with the tiles is an implementation detail behind the two services.

I don't believe this is a change to the policy for tiles, which would need an OWG vote, because the render endpoint isn't tiles