### PR TITLE
Edit the tile usage policy for clarity

### DIFF
--- a/policies/tiles.md
+++ b/policies/tiles.md
@@ -13,25 +13,25 @@ However, **OpenStreetMap's own servers are run entirely on donated resources.** 
 
 Below are the minimum requirements that users of tile.openstreetmap.org must adhere to. These may change in future, depending on available resources. Should any users or patterns of usage nevertheless cause problems to the service, access may still be blocked without prior notice. We will try to contact relevant parties if possible, but cannot guarantee this.
 
-But because OpenStreetMap data is free, many other organisations provide map tiles made from OSM data. If your project doesn't meet these requirements, you can get OSM-derived map tiles elsewhere.
+Because OpenStreetMap data is free, many other organisations provide map tiles made from OSM data. If your project doesn't meet our requirements, you can get OSM-derived map tiles elsewhere.
 
 Use of any OSMF provided service is further governed by the [OSMF Terms of Use](https://wiki.osmfoundation.org/wiki/Terms_of_Use).
 
 ## Requirements
 
-* Heavy use (e.g. distributing an app that uses tiles from openstreetmap.org) is **forbidden** without prior permission from the [Operations Working Group](https://wiki.osmfoundation.org/wiki/Operations_Working_Group). See below for alternatives.
+* Heavy use (e.g. distributing a heavy-usage app that uses tiles from openstreetmap.org) is **forbidden** without prior permission from the [Operations Working Group](https://wiki.osmfoundation.org/wiki/Operations_Working_Group). See below for alternatives.
 * Clearly display [license](https://wiki.openstreetmap.org/wiki/License) [attribution](https://wiki.osmfoundation.org/wiki/Licence/Attribution_Guidelines).
 * Do not actively or passively encourage copyright infringement.
-* Recommended: Do not hardcode any URL at tile.openstreetmap.org as doing so will limit your ability to react quickly if the service is disrupted or blocked.
+* Recommended: Do not hardcode any URL to tile.openstreetmap.org as doing so will limit your ability to react if the service is disrupted or blocked. In particular, switching should be possible without requiring a software update.
 * Recommended: add a link to [https://www.openstreetmap.org/fixthemap](https://www.openstreetmap.org/fixthemap) to allow your users to report and fix problems in our data.
 
 ## Technical Usage Requirements
 
-* **Valid [HTTP User-Agent](http://en.wikipedia.org/wiki/en:User_agent)** identifying application. Faking another app's User-Agent WILL get you blocked.
-* If known, a **valid [HTTP Referer](http://en.wikipedia.org/wiki/en:HTTP_Referer)**.
+* **Valid [HTTP User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent)** identifying application. Faking another app's User-Agent WILL get you blocked. Using a library's default User-Agent is **NOT** recommended.
+* When coming from a web page, a **valid [HTTP Referer](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer)**. Apps generally do not have a HTTP referer.
 * **DO NOT send no-cache headers**. ("Cache-Control: no-cache", "Pragma: no-cache" etc.)
 * **Cache Tile** downloads locally according to HTTP Expiry Header, alternatively a minimum of 7 days.
-* **Maximum of 2 download threads**. (Unmodified web browsers' download thread limits are acceptable.)
+* **Maximum of 2 download connections**. (Unmodified web browsers' download limits are acceptable.)
 
 Note: modern web browsers in standard configuration generally pass all the above technical requirements.
 
@@ -44,6 +44,8 @@ In particular, downloading an area of over 250 tiles at zoom level 13 or higher 
 ## Privacy
 
 Use of all services is subject to the [OpenStreetMap Foundation privacy policy](http://wiki.osmfoundation.org/wiki/Privacy_Policy). Please do not submit personal data or other confidential material to any of our services.
+
+We publish [anonymised, summarised data for research and other purposes](https://wiki.osmfoundation.org/wiki/Privacy_Policy#Data_we_receive_automatically) about usage of the tile service. This currently includes [aggregated data on tiles accessed and websites or apps using the service](https://planet.openstreetmap.org/tile_logs/) but may include other reports, including those generated on an ad-hoc basis.
 
 ## Changes to this policy
 
@@ -66,4 +68,4 @@ Setting up your own tile server:
 
 ------
 
-*This policy relates to the Standard ("Mapnik") tiles rendered and served by {a,b,c}.**tile.openstreetmap.org** as part of the OpenStreetMap project. It does not relate to other tiles that are viewable on the OpenStreetMap.org homepage, which may have their own usage policies. You should contact the individual projects, such as [OpenCycleMap](https://wiki.openstreetmap.org/wiki/OpenCycleMap), if you wish to use their tiles.*
+*This policy relates to the Standard ("OpenStreetMap Carto") tiles rendered and served by **tile.openstreetmap.org** as part of the OpenStreetMap project. It does not relate to other tiles that are viewable on the OpenStreetMap.org homepage, which may have their own usage policies. You should contact the individual projects, such as [OpenCycleMap](https://wiki.openstreetmap.org/wiki/OpenCycleMap), if you wish to use their tiles.*


### PR DESCRIPTION
This attempts to make the policy clearer to readers who may not
be as familiar with HTTP, as well as improving terminology, grammar
and some changes to parallel downloading to reflect HTTP/2 and HTTP/3.

There are no substantive changes to the policy