### PR TITLE
Fix link to 2023 budget report

### DIFF
--- a/_posts/2022-12-01-december.md
+++ b/_posts/2022-12-01-december.md
@@ -6,7 +6,7 @@ date: 2022-12-31 23:59:59
 
 ## Budget
 
-The OWG has submitted a [proposed 2023 budget](/2023/12/31/plan.html) to the board.
+The OWG has submitted a [proposed 2023 budget](/2022/12/31/plan.html) to the board.
 
 ## Site visit
 


### PR DESCRIPTION
There was a typo in the link - although it's the 2023 budget report, it was published in 2022 and so has 2022 in the path.