### PR TITLE
Add the OWG travel policy, as adopted 2023-03-09

### DIFF
--- a/policies/index.md
+++ b/policies/index.md
@@ -28,3 +28,4 @@ Our internal policies govern the way that OWG operates:
 * [Sysadmin Membership Policy]({{ site.baseurl }}/policies/sysadmin-membership)
 * [Hosting Provider Credit Policy]({{ site.baseurl }}/policies/hosting/)
 * [Service Classification Policy]({{ site.baseurl }}/policies/classification/)
+* [Operations Working Group Travel Policy]({{ site.baseurl }}/policies/travel/)

--- a/policies/travel.md
+++ b/policies/travel.md
@@ -12,7 +12,7 @@ See also: [OSMF policy on expense claims](https://wiki.osmfoundation.org/wiki/Fi
 For travel costs to OSMF sites to be expensed by the OSMF, the following rules must be followed:
 
 * The travel purpose needs to be announced to and approved by the OWG. The exact requirements for approval are at the discretion of the OWG.
-* Once approved, travel arrangements are usually to be made autonomously by the person travelling without requiring further approval from OWG or the board. However, inform the OWG and, if applicable, your point of contact on the personal committee about the plans.
+* Once approved, travel arrangements are usually to be made autonomously by the person travelling without requiring further approval from OWG or the board. However, inform the OWG and, if applicable, your point of contact on the personnel committee about the plans.
 * OWG-related travel may be mixed with private travel. The OSMF will pay for the costs that would have accrued for the same journey without a privately spent section of the journey. The OSMF part of the budget of travel arrangements with such mixed purpose needs to be approved by the OWG.
 * OWG includes an estimate about the frequency of travel required over the year in their annual budget. It informs the board if circumstances change and significantly more travel is needed.
 

--- a/policies/travel.md
+++ b/policies/travel.md
@@ -1,0 +1,23 @@
+---
+title: Operations Working Group Travel Policy
+permalink: /policies/sysadmin-membership/
+---
+
+# {{ page.title }}
+
+This policy describes the process for approving OWG-related travel and our expectations about the nature of travel expenses.
+
+See also: [OSMF policy on expense claims](https://wiki.osmfoundation.org/wiki/Finances#OSMF_policy_on_expense_claims)
+
+For travel costs to OSMF sites to be expensed by the OSMF, the following rules must be followed:
+
+* The travel purpose needs to be announced to and approved by the OWG. The exact requirements for approval are at the discretion of the OWG.
+* Once approved, travel arrangements are usually to be made autonomously by the person travelling without requiring further approval from OWG or the board. However, inform the OWG and, if applicable, your point of contact on the personal committee about the plans.
+* OWG-related travel may be mixed with private travel. The OSMF will pay for the costs that would have accrued for the same journey without a privately spent section of the journey. The OSMF part of the budget of travel arrangements with such mixed purpose needs to be approved by the OWG.
+* OWG includes an estimate about the frequency of travel required over the year in their annual budget. It informs the board if circumstances change and significantly more travel is needed.
+
+When making travel arrangements, we expect that you choose the travel options that allow you to make most efficient use of your time while keeping the cost in check. Choose the travel option that reduces stress for you and arrange travel times so that you are not exhausted at your destination. At the same time we expect that you actively look for cost-effective accommodation and means of transport. In particular, try to make travel arrangements as early as possible to avoid last-minute surcharges. All things equal, choose the more environmentally friendly option.
+
+OSMF usually covers the common modes of transport (public transport, commercial airlines and ships, car, and vehicle rental) and mid-range accommodation. If you think you require something else, check with OWG first.
+
+The board will review travel expenses from time to time and may impose additional restrictions, if expenses are considered excessive.


### PR DESCRIPTION
In the https://osmfoundation.org/wiki/Operations/Minutes/2023-03-09#Travel_policy meeting we did a live edit of the travel policy and agreed on it. Reviewing the minutes, I see that the changes suggested were some copyediting, making the purpose of the travel more general and not strictly related to hardware, and adding vehicle rental as an option for travel (e.g. for moving servers).

Looking at the text from the hackpad, all of these changes are reflected in the policy.

It's not clear if we formally adopted it as a policy, but it was agreed on at the time and may have fallen through the cracks in the minutes.

cc @lonvia 