### PR TITLE
Tile policy: tell people that using the http:// URL messes up referers.

### DIFF
--- a/policies/tiles.md
+++ b/policies/tiles.md
@@ -31,6 +31,7 @@ If you cannot meet these requirements, please use an **alternative OSM-derived s
 * Bulk download ("scrape") tiles or offer prefetch features.
 * Send `Cache-Control: no-cache`, `Pragma: no-cache`, or similar no-cache headers by default.
 * Set a restrictive Referrer-Policy that prevents the **HTTP Referer** header being sent.
+* Use the URL `http://tile.openstreetmap.org/{z}/{x}/{y}.png` if your site uses HTTPS. Doing so prevents HTTP referers from being sent.
 * Masquerade as another app's User-Agent, or rely on a library's default User-Agent.
 
 **You should (recommended):**


### PR DESCRIPTION
This spans from the discussion at https://github.com/Leaflet/Leaflet/pull/9883 .

I don't think web devs are mucking around with the referer policies in their javascript code; rather, if they use the http (not https) tile url template, the browser (applying the default policy) does not send the referer.

A simple note in the tile policy should clear things up for web devs.