### PR TITLE
Fix navbar toggle on mobile

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,13 +34,15 @@
           <div class="navbar-header">
             <a class="navbar-brand" href="{{ site.baseurl }}/">OSMF OWG</a>
           </div>
-          <ul class="nav navbar-nav">
-            <li><a href="{{ site.baseurl }}/">Home</a></li>
-            <li><a href="{{ site.baseurl }}/reports/">Reports</a></li>
-            <li><a href="{{ site.baseurl }}/post-mortems/">Post-mortems</a></li>
-            <li><a href="{{ site.baseurl }}/policies/">Policies</a></li>
-            <li><a href="{{ site.baseurl }}/meetings/">Meetings</a></li>
-          </ul>
+          <div class="collapse navbar-collapse" id="navbar">
+            <ul class="nav navbar-nav">
+              <li><a href="{{ site.baseurl }}/">Home</a></li>
+              <li><a href="{{ site.baseurl }}/reports/">Reports</a></li>
+              <li><a href="{{ site.baseurl }}/post-mortems/">Post-mortems</a></li>
+              <li><a href="{{ site.baseurl }}/policies/">Policies</a></li>
+              <li><a href="{{ site.baseurl }}/meetings/">Meetings</a></li>
+            </ul>
+          </div>
         </div>
       </div>
 
@@ -52,5 +54,7 @@
         </div>
       </footer>
     </div>
+
+    <script src="{{ site.baseurl }}/js/navbar.js"></script>
   </body>
 </html>

--- a/js/navbar.js
+++ b/js/navbar.js
@@ -1,0 +1,22 @@
+(function () {
+  var toggle = document.querySelector('.navbar-toggle[data-target="#navbar"]');
+  var target = document.getElementById('navbar');
+  if (!toggle || !target) return;
+
+  toggle.addEventListener('click', function (e) {
+    e.preventDefault();
+    var isOpen = target.classList.toggle('in');
+    toggle.classList.toggle('collapsed', !isOpen);
+    toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    toggle.blur();
+  });
+
+  document.querySelectorAll('#navbar .navbar-nav a').forEach(function (link) {
+    link.addEventListener('click', function () {
+      target.classList.remove('in');
+      toggle.classList.add('collapsed');
+      toggle.setAttribute('aria-expanded', 'false');
+      toggle.blur();
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
On mobile viewports, the navbar toggle button did nothing, tapping it neither opened nor closed the menu. This fix makes the responsive navbar work as expected.

### Before
On a mobile viewport, the navbar button does not work and menu is always opened:

https://github.com/user-attachments/assets/9fe83579-607a-4483-9da4-0fa00ad77fb2

### After
The toggle now opens/closes the menu on tap:

https://github.com/user-attachments/assets/e64462a1-1de3-46cf-a8da-f4131756e9f5

## Root cause
The toggle button relied on Bootstrap's JavaScript collapse plugin (via `data-toggle="collapse"`), which requires jQuery, but neither was ever loaded by the site. There was also no `#navbar` element for the button's `data-target` to point at, so the menu could never collapse or expand.